### PR TITLE
removes cdns and uses the public vendor assets

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -7,10 +7,10 @@
 
     <base href="/">
     <title>MEAN Seed</title>
-    
+
     <!-- STYLESHEETS -->
-    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
-    <link rel="stylesheet" href="http://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css">
+    <link rel="stylesheet" href="/vendor/bootstrap/dist/css/bootstrap.css">
+    <link rel="stylesheet" href="/vendor/font-awesome/css/font-awesome.css">
     <link rel="stylesheet" href="/css/animate.css">
     <link rel="stylesheet" href="/css/style.css">
   </head>
@@ -51,14 +51,12 @@
 
     <!-- ANGULAR APP INSERTER HERE -->
     <div ui-view class="container"></div>
-    
+
   </body>
-  
+
   <!-- THIRD PARTY LIBRARIES -->
-  <script src="//code.jquery.com/jquery-1.9.1.js"></script>
-  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
-  <script src="//maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
-  <script src="//code.jquery.com/ui/1.10.3/jquery-ui.js"></script>
+  <script type="text/javascript" src="/vendor/jquery/dist/jquery.min.js"></script>
+  <script type="text/javascript" src="/vendor/bootstrap/dist/js/bootstrap.js"></script>
   <script type="text/javascript" src="/vendor/angular/angular.js"></script>
   <script type="text/javascript" src="/vendor/angular-resource/angular-resource.js"></script>
   <script type="text/javascript" src="/vendor/angular-ui-router/release/angular-ui-router.js"></script>

--- a/views/templates/posts-index.html
+++ b/views/templates/posts-index.html
@@ -10,7 +10,7 @@
   <li ng-repeat="post in posts" class='list-group-item'>
     {{post.body}}
     <a href="#" class='pull-right' ng-click="deletePost(post)">
-      <i class='icon ion-close-circled'></i>
+      <i class='fa fa-times-circle'></i>
     </a>
   </li>
 </ul>


### PR DESCRIPTION
I saw that you had included the cdn hrefs for the js and css. I thought that since we were using bower  that it didn't make much sense so I fixed it.
